### PR TITLE
Support newer versions of PhantomJS

### DIFF
--- a/keyboard-event.js
+++ b/keyboard-event.js
@@ -70,7 +70,7 @@ else if (document.implementation.hasFeature('KeyboardEvent', '3.0')) {
 else if (document.createEventObject) {
   KeyboardEvent = IE8KeyboardEvent;
 }
-else if (navigator.userAgent == 'PhantomJS') {
+else if (navigator.userAgent.indexOf('PhantomJS') !== -1) {
   // seems to support DL3 keyboard events even though it doesn't claim to
   KeyboardEvent = DL3KeyboardEvent;
 }


### PR DESCRIPTION
Newer Versions of PhantomJS have an userAgents string like this:
`Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1`